### PR TITLE
Switch to grunt-download-electron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ pom.xml
 
 *.diff
 
-/atom-shell
+/electron
 
 /scripts/add-lein-profile

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,9 +65,9 @@ grunt.initConfig({
     'app/bin/lein.jar': leinJarUrl
   },
 
-  'download-atom-shell': {
+  'download-electron': {
     version: '0.20.5',
-    outputDir: 'atom-shell'
+    outputDir: 'electron'
   }
 
 });
@@ -79,7 +79,7 @@ grunt.initConfig({
 grunt.loadNpmTasks('grunt-contrib-less');
 grunt.loadNpmTasks('grunt-contrib-watch');
 grunt.loadNpmTasks('grunt-curl');
-grunt.loadNpmTasks('grunt-download-atom-shell');
+grunt.loadNpmTasks('grunt-download-electron');
 if (os === "mac") {
   grunt.loadNpmTasks('grunt-appdmg');
 }
@@ -91,7 +91,7 @@ grunt.loadNpmTasks('winresourcer');
 
 grunt.registerTask('setup', [
   'curl',
-  'download-atom-shell',
+  'download-electron',
   'ensure-config-exists',
   'build-lein-profile-tool'
 ]);
@@ -150,7 +150,7 @@ grunt.registerTask('launch', function() {
     mac:  "Atom.app/Contents/MacOS/Atom",
     linux:  "atom"
   }[os];
-  exec(path.join("atom-shell", exe) + " app");
+  exec(path.join("electron", exe) + " app");
 });
 
 //------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ function getBuildMeta() {
 
 function getReleasePaths(build) {
   var paths = {
-    atom: "atom-shell",
+    atom: "electron",
     builds: "builds",
     devApp: "app",
     rootPkg: "package.json"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grunt-contrib-less": "0.11.4",
     "grunt-contrib-watch": "0.6.1",
     "grunt-curl": "2.0.3",
-    "grunt-download-atom-shell": "0.10.0",
+    "grunt-download-electron": "2.1.0",
     "winresourcer": "0.9.0",
     "moment": "2.9.0",
     "shelljs": "0.3.0"


### PR DESCRIPTION
I bumped into this error:

```
ewq:~/src/cuttle(master=)$ grunt setup
Running "curl:app/bin/lein.jar" (curl) task
File "app/bin/lein.jar" created.

Running "download-atom-shell" task
>> Cannot find atom-shell v0.20.5 from GitHub [Error: Not Found]
Warning: Task "download-atom-shell" failed. Use --force to continue.

Aborted due to warnings.
```

The `atom/atom-shell` repo has been renamed to `atom/electron` as part of their naming transition! You can still use `grunt-download-electron` which knows about the new repo name to grab the old atom shells.

Note: If you bump into this issue after updating:

```
 grunt fresh-build
dyld: lazy symbol binding failed: Symbol not found: _node_module_register
  Referenced from: /Users/simon/src/cuttle/node_modules/grunt-appdmg/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias/build/Release/volume.node
  Expected in: dynamic lookup

dyld: Symbol not found: _node_module_register
  Referenced from: /Users/simon/src/cuttle/node_modules/grunt-appdmg/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias/build/Release/volume.node
  Expected in: dynamic lookup

Trace/BPT trap: 5
```

Nuking `node_modules` and a fresh `npm install` does the trick.
